### PR TITLE
Enable extension to be run on GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "description": "Adds an avatar to the panel. Controllability: shades, buttons (turn notifications on/off, sleep, off), visibility of username and hostname",
   "version": 1,
   "shell-version": [
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/pawelswiszcz/Avatar-Gnome-Shell-Extension"
 }


### PR DESCRIPTION
So far from my testing, just adding GNOME 42 to the extension's compatible shell versions works. Note that this fix simply makes it run on GNOME 42 and does not add any new features or fix anything.