### PR TITLE
Hide MPRIS from calendar when displaying own

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -486,6 +486,8 @@ class Extension {
             this.iconMenuItem.actor.get_last_child().add_child(avatar);
         }
 
+        let calendarMpris = Main.panel.statusArea.dateMenu._messageList._mediaSection;
+
         if (this.settings.get_boolean('show-media-center')) {
             this._mediaSectionMenuItem = new PopupMenu.PopupMenuItem('', { hover: false });
             Main.panel.statusArea.aggregateMenu.menu.addMenuItem(this._mediaSectionMenuItem, 1);
@@ -499,8 +501,13 @@ class Extension {
             this._mediaSectionMenuItem.actor.get_last_child().add_child(this._mediaSection);
 
             mediaMenuItem = this._mediaSectionMenuItem;
-        }
 
+            calendarMpris._shouldShow = () => false;
+            calendarMpris.hide ();
+        } else {
+	    calendarMpris._shouldShow = () => true;
+	    calendarMpris.show ();
+	}
     }
 
     setHorizontalStyle(user) {

--- a/extension.js
+++ b/extension.js
@@ -505,9 +505,9 @@ class Extension {
             calendarMpris._shouldShow = () => false;
             calendarMpris.hide ();
         } else {
-	    calendarMpris._shouldShow = () => true;
-	    calendarMpris.show ();
-	}
+            calendarMpris._shouldShow = () => true;
+            calendarMpris.show ();
+        }
     }
 
     setHorizontalStyle(user) {


### PR DESCRIPTION
There is no point in the media player to be in both Calendar and Status area, so let's just hide it from calendar when the media player option is active in extension, then enable it in calendar if the extension shouldn't show it.