### PR TITLE
Add logic to show calendar mpris when extension is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Available on gnome EGO:
 [<img src="assets/get-it-on-ego.svg" height="100">](https://extensions.gnome.org/extension/4782/avatar/)
 
 # Changelog
+v 13
+
+- Fix default mpris notifications not showing when extensions' mpris is enabled and extension is disabled
+
 v 12
 
 - Refactor UserWidget

--- a/extension.js
+++ b/extension.js
@@ -36,6 +36,7 @@ let iconMenuItem = null;
 
 let mediaMenuItem = null;
 
+let calendarMpris = Main.panel.statusArea.dateMenu._messageList._mediaSection;
 
 function resetAfterChange() {
     //Disconnects systemMenu
@@ -51,6 +52,8 @@ function resetAfterChange() {
 
     if (mediaMenuItem) {
         mediaMenuItem.destroy();
+        calendarMpris._shouldShow = () => true;
+        calendarMpris.show();
     }
 
 }
@@ -136,8 +139,6 @@ class Extension {
             let avatar = this.setVerticalStyle(user);
             this.iconMenuItem.actor.get_last_child().add_child(avatar);
         }
-
-        let calendarMpris = Main.panel.statusArea.dateMenu._messageList._mediaSection;
 
         if (this.settings.get_boolean('show-media-center')) {
             this._mediaSectionMenuItem = new PopupMenu.PopupMenuItem('', { hover: false });

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "avatar@pawel.swiszcz.com",
   "name": "Avatar",
   "description": "Adds an avatar to the panel. Controllability: shades, buttons (turn notifications on/off, sleep, off), visibility of username and hostname",
-  "version": 12,
+  "version": 13,
   "shell-version": [
     "41",
     "42"


### PR DESCRIPTION
When extension's mpris is enabled and extension is disabled callendar's mpris stays hidden. This commit fixes that and shows callendar mpris when extension is being disabled.